### PR TITLE
Fix Linux compilation by adding missing cstdint include

### DIFF
--- a/src/qscint/src/xmlMatchedTagsHighlighter.h
+++ b/src/qscint/src/xmlMatchedTagsHighlighter.h
@@ -20,6 +20,7 @@
 //#include <windows.h>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class QsciScintilla;
 


### PR DESCRIPTION
## Summary
Add missing `cstdint` header to `xmlMatchedTagsHighlighter.h` to fix Linux compilation.

## Problem
While the code compiles successfully in Qt Creator, it fails when building on Linux command line due to missing `cstdint` include. This header is needed for standard integer type definitions.

## Test plan
- [x] Verified compilation works on Linux command line after adding the include
- [x] Still compiles in Qt Creator as before
- [x] No functional changes introduced

🤖 Generated with [Claude Code](https://claude.ai/code)